### PR TITLE
Disable ColorKeyword

### DIFF
--- a/config/style_guides/scss.yml
+++ b/config/style_guides/scss.yml
@@ -8,8 +8,7 @@ linters:
     enabled: false
     convention: zero
   ColorKeyword:
-    enabled: true
-    severity: warning
+    enabled: false
   ColorVariable:
     enabled: true
   Comment:


### PR DESCRIPTION
[Reference](https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#colorkeyword)

I think it's silly that we should extract `white` into a variable (probably named `$white`) and use that instead of just using the built in color name.

Examples:
- https://github.com/mynewsdesk/mndx-story/pull/9#discussion-diff-38841084
- https://github.com/mynewsdesk/mndx-story/pull/9#discussion_r38841105
