### PR TITLE
Update rubocop

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -318,8 +318,8 @@ Style/RegexpLiteral:
     characters. Use %r only for regular expressions matching more than `MaxSlashes`
     '/' character.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-r
-  Enabled: false
-  MaxSlashes: 1
+  EnforcedStyle: slashes
+  AllowInnerSlashes: false
 Style/Semicolon:
   Description: Don't use semicolons to terminate expressions.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-semicolon
@@ -633,7 +633,7 @@ Style/BlockComments:
 Style/BlockEndNewline:
   Description: Put end statement of multiline block on its own line.
   Enabled: true
-Style/Blocks:
+Style/BlockDelimiters:
   Description: Avoid using {...} for multi-line blocks (multiline chaining is always
     ugly). Prefer {...} over do...end for single-line blocks.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#single-line-blocks
@@ -911,10 +911,10 @@ Style/UnneededPercentQ:
   Description: Checks for %q/%Q when single quotes or double quotes would do.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-q
   Enabled: true
-Style/UnneededPercentX:
+Style/CommandLiteral:
   Description: Checks for %x when `` would do.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-x
-  Enabled: true
+  AllowInnerBackticks: false
 Style/VariableInterpolation:
   Description: Don't interpolate global, instance and class variables directly in
     strings.

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -314,9 +314,7 @@ Style/RedundantReturn:
   Enabled: true
   AllowMultipleReturnValues: false
 Style/RegexpLiteral:
-  Description: Use %r for regular expressions matching more than `MaxSlashes` '/'
-    characters. Use %r only for regular expressions matching more than `MaxSlashes`
-    '/' character.
+  Description: Use %r only for regular expressions matching at least one '/' character.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-r
   EnforcedStyle: slashes
   AllowInnerSlashes: false
@@ -912,8 +910,11 @@ Style/UnneededPercentQ:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-q
   Enabled: true
 Style/CommandLiteral:
-  Description: Checks for %x when `` would do.
+  Description: Avoid the use of %x unless you're going to invoke a command with backquotes in it(which is rather unlikely).
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-x
+  EnforcedStyle: backticks
+
+
   AllowInnerBackticks: false
 Style/VariableInterpolation:
   Description: Don't interpolate global, instance and class variables directly in

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "resque", "~> 1.25.0"
 gem "resque-retry"
 gem "resque-sentry"
 gem "resque-timeout"
-gem "rubocop", "0.29.1"
+gem "rubocop", "~> 0.29"
 gem "sass-rails"
 gem "scss-lint", "0.34.0", require: false
 gem "sentry-raven"

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "resque", "~> 1.25.0"
 gem "resque-retry"
 gem "resque-sentry"
 gem "resque-timeout"
-gem "rubocop", "~> 0.29"
+gem "rubocop", "~> 0.34"
 gem "sass-rails"
 gem "scss-lint", "0.34.0", require: false
 gem "sentry-raven"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,9 +44,9 @@ GEM
       rails (>= 3, < 5)
     angularjs-rails (1.2.22)
     arel (6.0.0)
-    ast (2.0.0)
-    astrolabe (1.3.0)
-      parser (>= 2.2.0.pre.3, < 3.0)
+    ast (2.1.0)
+    astrolabe (1.3.1)
+      parser (~> 2.2)
     attr_extras (3.1.0)
     bourbon (4.1.0)
       sass (~> 3.3)
@@ -178,7 +178,7 @@ GEM
       omniauth (~> 1.2)
     paranoia (2.0.2)
       activerecord (~> 4.0)
-    parser (2.2.0.3)
+    parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
     pg (0.17.1)
     phantomjs (1.9.8.0)
@@ -187,7 +187,7 @@ GEM
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
-    powerpack (0.1.0)
+    powerpack (0.1.1)
     rack (1.6.0)
     rack-protection (1.5.3)
       rack
@@ -266,13 +266,13 @@ GEM
       rspec-mocks (~> 3.1.0)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
-    rubocop (0.29.1)
+    rubocop (0.34.1)
       astrolabe (~> 1.3)
-      parser (>= 2.2.0.1, < 3.0)
+      parser (>= 2.2.2.5, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
-    ruby-progressbar (1.7.1)
+    ruby-progressbar (1.7.5)
     rufus-scheduler (3.0.9)
       tzinfo
     safe_yaml (1.0.4)
@@ -375,7 +375,7 @@ DEPENDENCIES
   resque-sentry
   resque-timeout
   rspec-rails (>= 2.14)
-  rubocop (= 0.29.1)
+  rubocop (~> 0.29)
   sass-rails
   scss-lint (= 0.34.0)
   sentry-raven


### PR DESCRIPTION
When I tried to run rubocop locally I installed the newest rubocop and it complained about some illegal config settings (the naming of the options had changed) so I updated the .ruby-style.yml to use the new config names.

Style/Blocks -> Style/BlockDelimiters # just renaming

Style/UnneededPercentX -> Style/CommandLiteral # in this style name change the naming of the options also changed but I'm pretty I use the "correct options" one question though should I update the comments to the [comments in the default styleguide](https://github.com/bbatsov/rubocop/blob/master/config/default.yml#L300-L312)?

When changing to the new Style/RegexpLiteral option naming I had to make a slight change in the actual meaning of the rule (I think).
Previously there was a maxSlashes option which we had configured to 1, which I think would mean that we where allowed to write code like `/\//` but not not `/\/\//`. With the new "options api" it was not possible to set any maxslashes limit, you could just allow or dissallow the usage of slashes in `//` regexps, so the new rule is that we enforce the use of `%r{xxx}` when there's one or more slashes in the regexp. Which I think is a good change, do you agree?
