### PR TITLE
Disable warning 138 in JSHint

### DIFF
--- a/config/style_guides/mynewsdesk/javascript.json
+++ b/config/style_guides/mynewsdesk/javascript.json
@@ -33,5 +33,6 @@
   "quotmark": true,
   "trailing": true,
   "undef": true,
-  "unused": true
+  "unused": true,
+  "-W138": false
 }


### PR DESCRIPTION
Warning 138:

> Regular parameters cannot come after default parameters.

This warning seems pretty weird to have since when using `redux` this seems to
be a convention for initializing the state in a reducer.

The warning was added in JSHint here: https://github.com/jshint/jshint/pull/2543
