### PR TITLE
Set camelcase to false

### DIFF
--- a/config/style_guides/mynewsdesk/javascript.json
+++ b/config/style_guides/mynewsdesk/javascript.json
@@ -2,7 +2,7 @@
   "asi": true,
   "bitwise": true,
   "browser": true,
-  "camelcase": true,
+  "camelcase": false,
   "curly": true,
   "esnext": true,
   "forin": true,


### PR DESCRIPTION
Open for discussion:
Since we get a lot of keys from ruby with snake_case convention I think it make more sense to not have this warning.

Another option would be to always use bracket-notation when accesing snake case.

Option 1:

``` javascript
// Merge of this PR

// Bad
let id = obj['resource_id'];

// Good
let id = obj.resource_id
```

Option 2:

``` javascript
// Don't merge this PR

// Bad
let id = obj.resource_id;

// Good
let id = obj['resource_id'];
```

Thoughts?
