### PR TITLE
Add endpoint to clean database

### DIFF
--- a/app/controllers/database_cleaner_controller.rb
+++ b/app/controllers/database_cleaner_controller.rb
@@ -1,0 +1,9 @@
+class DatabaseCleanerController < ApplicationController
+  skip_before_filter :authenticate
+
+  def index
+    deleted = Build.where("created_at <= ?", 1.week.ago).destroy_all
+
+    render json: { message: "#{deleted.length} builds removed" }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Houndapp::Application.routes.draw do
   get "/sign_out", to: "sessions#destroy"
   get "/configuration", to: "pages#configuration"
   get "/faq", to: "pages#show", id: "faq"
+  get "/database_cleaner", to: "database_cleaner#index"
 
   resource :account, only: [:show]
   resources :builds, only: [:create]


### PR DESCRIPTION
To avoid free hobby dev database on heroku getting filled up and becoming unusable.

Can be hit manually but will setup newrelic or pingdom to hit the url to keep things clean automatically.

Not using any password protection etc is deliberate. There is nothing to hide here, just want the simplest possible solution to get out of the "too many rows" problem.

Also not using resque-scheduler for a chron job style cleanup is deliberate since this is simpler and doesn't require adding a $30 worker instance to run the scheduler.
