### PR TITLE
Remove the trailing comma warning

### DIFF
--- a/config/style_guides/mynewsdesk/ruby.yml
+++ b/config/style_guides/mynewsdesk/ruby.yml
@@ -1,12 +1,6 @@
 inherit_from:
   - ../ruby.yml
 
-Style/TrailingComma:
-  # If EnforcedStyleForMultiline is comma, the cop allows a comma after the
-  # last item of a list, but only for lists where each item is on its own line.
-  EnforcedStyleForMultiline: comma
-  Enabled: true
-
 Lint/UnusedBlockArgument:
   Enabled: false
 


### PR DESCRIPTION
This PR allows a developer to write a hash like this: 

``` ruby
hash = {
  foo: bar,
  bob: dole
}
```

IMO that way of writing Ruby hashes should be allowed and Hound should not "force" a dev to add a comma which is difficult to understand. Also it follows better the JSONified way of writing Ruby 2.0 hashes.
