### PR TITLE
Increase js max line length

### DIFF
--- a/config/style_guides/mynewsdesk/javascript.json
+++ b/config/style_guides/mynewsdesk/javascript.json
@@ -8,7 +8,7 @@
   "forin": true,
   "immed": true,
   "latedef": "nofunc",
-  "maxlen": 80,
+  "maxlen": 100,
   "newcap": true,
   "noarg": true,
   "noempty": true,


### PR DESCRIPTION
What does the team think about increasing the max line length? In ruby we have 120, however in javascript chapter there been discussions about using Airbnb's styleguide as a baseline and they propose 100.

Opinions?
