### PR TITLE
Disable the ImportantRule in SCSS

### DIFF
--- a/config/style_guides/mynewsdesk/scss.yml
+++ b/config/style_guides/mynewsdesk/scss.yml
@@ -42,7 +42,7 @@ linters:
   IdSelector:
     enabled: true
   ImportantRule:
-    enabled: true
+    enabled: false
   ImportPath:
     enabled: true
     leading_underscore: false


### PR DESCRIPTION
Since we're using utility classes and agreed on using `!important` on them (for sanity) I think we should ignore this rule in the linter and take that when reviewing instead. This will remove hound complaints for utility classes.

Thoughts? :smile: