### PR TITLE
Stop breaking the builds

### DIFF
--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -76,25 +76,17 @@ class BuildRunner
 
   def create_resulting_status
     if violations.any?
-      create_failure_status
+      create_success_status I18n.t(:failure_status)
     else
-      create_success_status
+      create_success_status I18n.t(:success_status)
     end
   end
 
-  def create_success_status
+  def create_success_status(message)
     github.create_success_status(
       payload.full_repo_name,
       payload.head_sha,
-      I18n.t(:success_status)
-    )
-  end
-
-  def create_failure_status
-    github.create_failure_status(
-      payload.full_repo_name,
-      payload.head_sha,
-      I18n.t(:failure_status)
+      message,
     )
   end
 

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -106,7 +106,7 @@ describe BuildRunner, '#run' do
           "headsha",
           "Hound is busy reviewing changes..."
         )
-        expect(github_api).to have_received(:create_failure_status).with(
+        expect(github_api).to have_received(:create_success_status).with(
           "test/repo",
           "headsha",
           "Hound detected a disturbance in the force."


### PR DESCRIPTION
Revert to the default behaviour of hound: to just give feedback but don't break builds.